### PR TITLE
fix: support Electron 5 (ref #385)

### DIFF
--- a/blueprints/ember-electron/files/ember-electron/main.js
+++ b/blueprints/ember-electron/files/ember-electron/main.js
@@ -6,7 +6,20 @@ const protocolServe = require('electron-protocol-serve');
 let mainWindow = null;
 
 // Registering a protocol & schema to serve our Ember application
-protocol.registerStandardSchemes(['serve'], { secure: true });
+if (typeof protocol.registerSchemesAsPrivileged === 'function') {
+  // Available in Electron >= 5
+  protocol.registerSchemesAsPrivileged([{
+    scheme: 'serve',
+    privileges: {
+      secure: true,
+      standard: true
+    }
+  }]);
+}
+else {
+  // For compatibility with Electron < 5
+  protocol.registerStandardSchemes(['serve'], { secure: true });
+}
 protocolServe({
   cwd: join(__dirname || resolve(dirname('')), '..', 'ember'),
   app,

--- a/lib/resources/shim-head.js
+++ b/lib/resources/shim-head.js
@@ -4,7 +4,18 @@
 
   // On linux the renderer process doesn't inherit the main process'
   // environment, so we need to fall back to using the remote module.
-  const serveIndex = process.env.ELECTRON_PROTOCOL_SERVE_INDEX || require('electron').remote.process.env.ELECTRON_PROTOCOL_SERVE_INDEX;
+  let serveIndex;
+  // If nodeIntegration is disabled, this will throw and serveIndex will remain
+  // undefined, which is fine because we only need it to fix module search paths
+  // that aren't relevant if node integration is disabled.
+  try {
+    serveIndex = process.env.ELECTRON_PROTOCOL_SERVE_INDEX || require('electron').remote.process.env.ELECTRON_PROTOCOL_SERVE_INDEX;
+  } catch (e) {
+    // When nodeIntegration is false we expect process to be undefined. Don't swallow the exception if something else is wrong
+    if (e.message !== "process is not defined") {
+      throw e;
+    }
+  }
 
   if (serveIndex && window.location.protocol !== 'file:') {
     // Using electron-protocol-serve to load index.html via a 'serve:' URL

--- a/lib/test-support/test-main.js
+++ b/lib/test-support/test-main.js
@@ -27,7 +27,18 @@ let emberAppDir = resolve(dirname(indexPath), '..');
 let relPath = relative(emberAppDir, indexPath);
 const emberAppLocation = `serve://dist/${relPath}${indexQuery}`;
 
-protocol.registerStandardSchemes(['serve'], { secure: true });
+if (typeof protocol.registerSchemesAsPrivileged === 'function') {
+  protocol.registerSchemesAsPrivileged([{
+    scheme: 'serve',
+    privileges: {
+      secure: true,
+      standard: true,
+    },
+  }]);
+}
+else {
+  protocol.registerStandardSchemes(['serve'], { secure: true });
+}
 protocolServe({
   cwd: emberAppDir,
   app,


### PR DESCRIPTION
Use `protocol.registerSchemesAsPrivileged`, if available, since
`protocol.registerStandardSchemes` was removed in Electron 5.0.0
See https://github.com/electron/electron/blob/master/docs/api/breaking-changes.md#privileged-schemes-registration

Note: blueprint changed, so users will have to update their `ember-electron/main.js` file as well (or re-run `ember install ember-electron` to overwrite).