### PR TITLE
fix: enable node integration in tests

### DIFF
--- a/lib/test-support/test-main.js
+++ b/lib/test-support/test-main.js
@@ -74,6 +74,7 @@ app.on('ready', function onReady() {
     height: 600,
     webPreferences: {
       backgroundThrottling: false,
+      nodeIntegration: true,
     },
   });
 


### PR DESCRIPTION
So Electron >=5 behaves the same as Electron <5.