### PR TITLE
fix: Disable fingerprinting on images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://github.com/adopted-ember-addons/ember-electron/raw/gh-pages/assets/logo-github%402x.png" alt="Ember-Electron logo showing an electron orbiting a flame" width="300" height="250"></p>
+<p align="center"><img src="https://github.com/adopted-ember-addons/ember-electron/raw/gh-pages/img/logo-github%402x.png" alt="Ember-Electron logo showing an electron orbiting a flame" width="300" height="250"></p>
 
 # Ember-Electron
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-    // Add options here
+    fingerprint: {
+      extensions: ['js', 'css', 'map']
+    }
   });
 
   /*

--- a/tests/dummy/app/templates/docs/index.md
+++ b/tests/dummy/app/templates/docs/index.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://github.com/adopted-ember-addons/ember-electron/raw/gh-pages/assets/logo-github%402x.png" alt="Ember-Electron logo showing an electron orbiting a flame" width="300" height="250"></p>
+<p align="center"><img src="https://github.com/adopted-ember-addons/ember-electron/raw/gh-pages/img/logo-github%402x.png" alt="Ember-Electron logo showing an electron orbiting a flame" width="300" height="250"></p>
 
 # Ember-Electron
 


### PR DESCRIPTION
This should allow us to point to the actual path in the markdown files.