### PR TITLE
doc: remove duplicate `docs/` path segment

### DIFF
--- a/tests/dummy/app/templates/docs/index.md
+++ b/tests/dummy/app/templates/docs/index.md
@@ -20,18 +20,18 @@ To see a real world example, check out [Ghost Desktop](https://github.com/trygho
 ## Documentation
 
 ### Basics
-- [Installation](docs/guides/installation)
-- [Usage](docs/guides/usage)
-- [Structure](docs/guides/structure)
+- [Installation](guides/installation)
+- [Usage](guides/usage)
+- [Structure](guides/structure)
 
 ### Advanced Guides
-- [Upgrading from ember-electron 2.x to 3.x](docs/guides/upgrading)
-- [Development and Debugging](docs/guides/development-and-debugging)
-- [Testing on CI (Travis, AppVeyor, CircleCI, etc)](docs/guides/ci)
+- [Upgrading from ember-electron 2.x to 3.x](guides/upgrading)
+- [Development and Debugging](guides/development-and-debugging)
+- [Testing on CI (Travis, AppVeyor, CircleCI, etc)](guides/ci)
 
 ### FAQ
-- [Common issues](docs/faq/common-issues)
-- [Security concerns](docs/faq/security)
+- [Common issues](faq/common-issues)
+- [Security concerns](faq/security)
 
 Somethings missing? Contributions to our docs are welcome!
 


### PR DESCRIPTION
I was browsing https://adopted-ember-addons.github.io/ember-electron/versions/v3.0.0-beta.0/docs/#documentation and noticed that most of the links go to a blank/bogus page. Looks like this is because the path is relative and this file is in `docs` already, so resultant URLs contain `docs/docs`.