### PR TITLE
fix: install devtron and ember-inspector

### DIFF
--- a/forge/template.js
+++ b/forge/template.js
@@ -54,7 +54,8 @@ async function updatePackageJson(dir) {
 
 module.exports = {
   devDependencies: [
-    'devtron'
+    'devtron',
+    'ember-inspector'
   ],
   dependencies: [
     'electron-protocol-serve'

--- a/index.js
+++ b/index.js
@@ -23,6 +23,16 @@ module.exports = {
     };
   },
 
+  included(app) {
+    this._super.included.apply(this, arguments);
+
+    if (process.env.EMBER_CLI_ELECTRON) {
+      if ([ 'development', 'test' ].includes(app.env)) {
+        app.import('vendor/install-extensions.js');
+      }
+    }
+  },
+
   contentFor(type) {
     const { env: { EMBER_CLI_ELECTRON } } = process;
 

--- a/node-tests/fixtures/ember-test/test-index-extra.js
+++ b/node-tests/fixtures/ember-test/test-index-extra.js
@@ -4,3 +4,15 @@ fileUrl('foo.html');
 // Make sure local libraries are loadable
 const helper = require('../src/helper');
 helper();
+
+const { app, BrowserWindow } = require('electron');
+
+app.once('browser-window-created', (event, win) => {
+  win.webContents.on('did-finish-load', () => {
+    let extensions = BrowserWindow.getDevToolsExtensions();
+    if (!extensions.hasOwnProperty('devtron') || !extensions.hasOwnProperty('Ember Inspector')) {
+      console.error('devtron and/or ember-inspector not installed', Object.keys(extensions)); // eslint-disable-line no-console
+      app.exit(-1);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint:js": "eslint .",
     "test": "yarn test-fast && yarn test-slow",
     "test-fast": "mocha node-tests/integration/**/*.js",
-    "test-slow": "mocha ./node-tests/acceptance/**/*.js"
+    "test-slow": "mocha node-tests/acceptance/**/*.js"
   },
   "dependencies": {
     "@electron-forge/cli": "^6.0.0-beta.45",

--- a/vendor/install-extensions.js
+++ b/vendor/install-extensions.js
@@ -30,34 +30,28 @@ function installExtensions() {
     let path = window.requireNode('path');
     let fs = window.requireNode('fs');
 
-    let eiLocation = window.requireNode.resolve('ember-inspector');
-    let location = path.join(eiLocation, 'dist', 'chrome');
+    let location = path.dirname(window.requireNode.resolve('ember-inspector/dist/chrome/devtools.js'));
+    if (!location) {
+      console.warn('Unable to locate ember-inspector', err);
+      return;
+    }
 
-    fs.lstat(location, function(err, results) {
-      if (err) {
-        console.warn('Error loading Ember Inspector', err);
+    let { BrowserWindow } = window.requireNode('electron').remote;
+    let added = BrowserWindow.getDevToolsExtensions
+      && BrowserWindow.getDevToolsExtensions().hasOwnProperty('Ember Inspector');
+
+    if (!added) {
+      try {
+        BrowserWindow.addDevToolsExtension(location);
+      } catch(err) {
+        console.warn('Error enabling Ember Inspector', err)
         return;
       }
-
-      if (results && results.isDirectory && results.isDirectory()) {
-        let { BrowserWindow } = window.requireNode('electron').remote;
-        let added = BrowserWindow.getDevToolsExtensions
-          && BrowserWindow.getDevToolsExtensions().hasOwnProperty('Ember Inspector');
-
-        if (!added) {
-          try {
-            BrowserWindow.addDevToolsExtension(location);
-          } catch(err) {
-            console.warn('Error enabling Ember Inspector', err)
-            return;
-          }
-        }
-      }
-    });
+    }
   }
 
   installDevtron();
   installEmberInspector();
 }
 
-document.addEventListener('DOMContentLoaded', installExtension);
+document.addEventListener('DOMContentLoaded', installExtensions);


### PR DESCRIPTION
I apparently re-wrote some code to install these extensions and didn't test it at all, so:

* fix (and simplify a bit) the install-extensions code
* move electron-inspector to be a devDependency of the Electron project, since that's really where we need it (and that allows users to control the version, etc.)
* add a test to verify that the install-extensions code is working