### PR TITLE
doc: suggest including @3 suffix

### DIFF
--- a/tests/dummy/app/templates/docs/guides/upgrading.md
+++ b/tests/dummy/app/templates/docs/guides/upgrading.md
@@ -123,4 +123,4 @@ If you need to exclude files for other platforms from your packaged build, you c
 
 ### code/files/etc
 
-Anything else that was in the `ember-electron` in 2.x should be "just files" -- `.js` files `require`d from the main process or `requireNode`d from the Ember app, or other files accessed via the filesystem APIs. So these can be migrated into `electron-app` however seems best, updating the references to their paths in other source files as needed.
+Anything else that was in the `ember-electron` folder in 2.x should be "just files" -- `.js` files `require`d from the main process or `requireNode`d from the Ember app, or other files accessed via the filesystem APIs. So these can be migrated into `electron-app` however seems best, updating the references to their paths in other source files as needed.

--- a/tests/dummy/app/templates/docs/guides/upgrading.md
+++ b/tests/dummy/app/templates/docs/guides/upgrading.md
@@ -6,7 +6,7 @@ While upgrading from 2.x to 3.x should not be very time-consuming in most cases,
 
 ```sh
 yarn-or-npm remove ember-electron
-ember install ember-electron
+ember install ember-electron@3
 ```
 
 When prompted to overwrite `testem-electron.js`, choose `yes`.


### PR DESCRIPTION
Since `ember install ember-electron` will use the `latest` npm tag by default, these instructions won't work until that tag points to 3.x. Since these instructions are specifically for upgrading from 2.x to 3.x specifying `ember install ember-electron@3` seems like a reasonable solution.