### PR TITLE
Update to electron-forge beta 47

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  file: [ 'node-tests/helpers/test-setup' ]
+  file: [ 'node-tests/helpers/test-setup' ],
+  timeout: 5000
 };

--- a/forge/template.js
+++ b/forge/template.js
@@ -1,3 +1,4 @@
+const { BaseTemplate } = require('@electron-forge/template-base');
 const { promisify } = require('util');
 const path = require('path');
 const readFile = promisify(require('fs').readFile);
@@ -52,22 +53,37 @@ async function updatePackageJson(dir) {
   await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 }
 
-module.exports = {
-  devDependencies: [
-    'devtron',
-    'ember-inspector'
-  ],
-  dependencies: [
-    'electron-protocol-serve'
-  ],
+class EmberElectronTemplates extends BaseTemplate {
+  constructor() {
+    super(...arguments);
+    this.templateDir = path.join(__dirname, 'files');
+  }
+
+  get devDependencies() {
+    return [
+      'devtron',
+      'ember-inspector'
+    ];
+  }
+  get dependencies() {
+    return [
+      'electron-protocol-serve'
+    ];
+  }
+
   async initializeTemplate(dir) {
+    await super.initializeTemplate(...arguments);
+
     // delete source directory with default files
     await rimraf(path.join(dir, 'src'));
 
     // copy our initial content
-    await ncp(path.join(__dirname, 'files'), dir);
+    await ncp(this.templateDir, dir);
 
     await updateGitIgnore(dir);
     await updatePackageJson(dir);
   }
-};
+
+}
+
+module.exports = new EmberElectronTemplates();

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test-slow": "mocha node-tests/acceptance/**/*.js"
   },
   "dependencies": {
-    "@electron-forge/core": "^6.0.0-beta.45",
+    "@electron-forge/core": "6.0.0-beta.47",
     "broccoli-string-replace": "^0.1.2",
     "chalk": "^3.0.0",
     "debug": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -780,10 +780,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@electron-forge/async-ora@6.0.0-beta.46":
-  version "6.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@electron-forge/async-ora/-/async-ora-6.0.0-beta.46.tgz#fd8a30d96b9c4fccc613b044d6fe64f28bb72a1f"
-  integrity sha512-EE/j8TRUQxtzFjz7/G3UGNXiqcfNUIik73EI51AtVYbP5GhOkEEMlrKVEIEr30IglK4mht/gqlWVb8QwYMDnvg==
+"@electron-forge/async-ora@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/async-ora/-/async-ora-6.0.0-beta.47.tgz#8c16c5a67dec45c0b4c7b826ebbe66daab572e90"
+  integrity sha512-xy6W0US3jK4Ty8QwDDGhPdtOOfqer2szIqnkD3lbbGHwsWb0OUCBhzJgrVIqejrJby/gwAn4SrGIoJE+imryig==
   dependencies:
     colors "^1.4.0"
     debug "^4.1.0"
@@ -791,23 +791,26 @@
     ora "^4.0.3"
     pretty-ms "^5.0.0"
 
-"@electron-forge/core@^6.0.0-beta.45":
-  version "6.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@electron-forge/core/-/core-6.0.0-beta.46.tgz#5a10963f7b234587d1a602d7beaa80286b8d0839"
-  integrity sha512-x4XeJGU7XQrUdJVv5Rg4MaWFeSwkS6GDatA/HgbZ7BUHvkDzqR02qSmAOgOMkneE4V/HMB56/wY2D+IxUKbUUw==
+"@electron-forge/core@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/core/-/core-6.0.0-beta.47.tgz#805a547b99b8802f75fdf8c842fd16138a796645"
+  integrity sha512-3GuiuhhnWOHpCG894bQIaUQxBuVljmRcWmbIY8/PmVXU9O1141bHSqPNhS1cNzFsjwPk5qQ6vUIFeulsKTce7w==
   dependencies:
-    "@electron-forge/async-ora" "6.0.0-beta.46"
-    "@electron-forge/installer-base" "6.0.0-beta.46"
-    "@electron-forge/installer-deb" "6.0.0-beta.46"
-    "@electron-forge/installer-dmg" "6.0.0-beta.46"
-    "@electron-forge/installer-exe" "6.0.0-beta.46"
-    "@electron-forge/installer-rpm" "6.0.0-beta.46"
-    "@electron-forge/installer-zip" "6.0.0-beta.46"
-    "@electron-forge/maker-base" "6.0.0-beta.46"
-    "@electron-forge/plugin-base" "6.0.0-beta.46"
-    "@electron-forge/publisher-base" "6.0.0-beta.46"
-    "@electron-forge/shared-types" "6.0.0-beta.46"
-    "@electron-forge/template-webpack" "6.0.0-beta.46"
+    "@electron-forge/async-ora" "6.0.0-beta.47"
+    "@electron-forge/installer-base" "6.0.0-beta.47"
+    "@electron-forge/installer-deb" "6.0.0-beta.47"
+    "@electron-forge/installer-dmg" "6.0.0-beta.47"
+    "@electron-forge/installer-exe" "6.0.0-beta.47"
+    "@electron-forge/installer-rpm" "6.0.0-beta.47"
+    "@electron-forge/installer-zip" "6.0.0-beta.47"
+    "@electron-forge/maker-base" "6.0.0-beta.47"
+    "@electron-forge/plugin-base" "6.0.0-beta.47"
+    "@electron-forge/publisher-base" "6.0.0-beta.47"
+    "@electron-forge/shared-types" "6.0.0-beta.47"
+    "@electron-forge/template-base" "6.0.0-beta.47"
+    "@electron-forge/template-typescript" "6.0.0-beta.47"
+    "@electron-forge/template-typescript-webpack" "6.0.0-beta.47"
+    "@electron-forge/template-webpack" "6.0.0-beta.47"
     "@electron/get" "^1.6.0"
     colors "^1.4.0"
     cross-spawn-promise "^0.10.1"
@@ -829,110 +832,142 @@
     username "^5.1.0"
     yarn-or-npm "^3.0.1"
 
-"@electron-forge/installer-base@6.0.0-beta.46":
-  version "6.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@electron-forge/installer-base/-/installer-base-6.0.0-beta.46.tgz#a4858c06e9b2cdfbf628269d10875c6874105687"
-  integrity sha512-xC4Xv/Bk2day/YeXWO1kK/LMitCweA0Mab1k8WCxa1MGu55vFwWd6VR3vseULW/Ya8bkQs11LcwG3Ku0RSLcuA==
+"@electron-forge/installer-base@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/installer-base/-/installer-base-6.0.0-beta.47.tgz#eca22e87c100c8e28430a04045e51dc3c53711bb"
+  integrity sha512-WiotCce+86CzYygSW/WzKFk75vyrL8P3Pyq6ltrr0yVES1z9VLVppqklpKC6g92PJl+jaGeXwhqmZkECi7Zqdw==
   dependencies:
-    "@electron-forge/async-ora" "6.0.0-beta.46"
+    "@electron-forge/async-ora" "6.0.0-beta.47"
 
-"@electron-forge/installer-darwin@6.0.0-beta.46":
-  version "6.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@electron-forge/installer-darwin/-/installer-darwin-6.0.0-beta.46.tgz#3f93897be07c793754c2eb779b5ac880cf80530a"
-  integrity sha512-1NJQGF+hMp6UKWaQ34MboQJU5DQcQBm9Wmkc8fsGPsJjglDq/tJzi+DOD39+uMiEiEj7q2KAaOezHzTX0pZPYg==
+"@electron-forge/installer-darwin@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/installer-darwin/-/installer-darwin-6.0.0-beta.47.tgz#06d0f118965647f1044ed8ed1f9fd1e315a4d733"
+  integrity sha512-M9f63b/GjBfOl8p34yDMgqa1tgzTkaxaqGQZAtLAOutscVoV3LO+g+ibA+odzwy/LCxUCIPXIk/H7VTacOLkiA==
   dependencies:
-    "@electron-forge/async-ora" "6.0.0-beta.46"
-    "@electron-forge/installer-base" "6.0.0-beta.46"
+    "@electron-forge/async-ora" "6.0.0-beta.47"
+    "@electron-forge/installer-base" "6.0.0-beta.47"
     fs-extra "^8.1.0"
     sudo-prompt "^9.1.1"
 
-"@electron-forge/installer-deb@6.0.0-beta.46":
-  version "6.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@electron-forge/installer-deb/-/installer-deb-6.0.0-beta.46.tgz#f1cbdef195e22de7a7eff39be13b9144de2ca872"
-  integrity sha512-ikmUSzwfr8GT0VJ0Af5bd8rivqJ2UbOk5jmK6rzlmGQcuQbZ1glWNiAoGIKbKGv8kbEsZeTJ82QYVm1NNex8sA==
+"@electron-forge/installer-deb@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/installer-deb/-/installer-deb-6.0.0-beta.47.tgz#160e5acdf4683ed683b764fec588d7804b9b4a5a"
+  integrity sha512-vogZr8S8aNprwjRVM2b/C7tEZmRh41vm5gLsEXZBB/dWVXuekCaclL+4SkmUxiKL2vlVZpWk3ab8VMCv5ZJNEA==
   dependencies:
-    "@electron-forge/installer-linux" "6.0.0-beta.46"
+    "@electron-forge/installer-linux" "6.0.0-beta.47"
 
-"@electron-forge/installer-dmg@6.0.0-beta.46":
-  version "6.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@electron-forge/installer-dmg/-/installer-dmg-6.0.0-beta.46.tgz#3d703c09782841b391f70c094c772d62c6f1111a"
-  integrity sha512-2ncd1aHK36hcFw2o8PrFKuHV11gusTftnPajxyxACvOtk33z4UmxmgSvechUE7JDwLTUsr9jNWJMj+v1uOJdnQ==
+"@electron-forge/installer-dmg@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/installer-dmg/-/installer-dmg-6.0.0-beta.47.tgz#c97950e54a9905e74cbe6a3fb904556bd3326b5a"
+  integrity sha512-og3SsLNKa4t//Y1wWoKOPNE/fqN1pRAPrjxjJOBdnpHfnIQkdXSGb/5UrgdDGSaLB6rqs1Sw/uOGCMzIgAuxFg==
   dependencies:
-    "@electron-forge/installer-darwin" "6.0.0-beta.46"
+    "@electron-forge/installer-darwin" "6.0.0-beta.47"
     cross-spawn-promise "^0.10.1"
     debug "^4.1.0"
     fs-extra "^8.1.0"
 
-"@electron-forge/installer-exe@6.0.0-beta.46":
-  version "6.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@electron-forge/installer-exe/-/installer-exe-6.0.0-beta.46.tgz#4b1558e508f1d6e559cc6ebe7c3b5da66cda3947"
-  integrity sha512-ocRgb645q6Ssf7pBg3nbh1qJSVljlGTCIDbhUfTQzFYJ+UyreMH1jYKuMArHHWzfE00PFmJ0vlhvVOeqQoR1kg==
+"@electron-forge/installer-exe@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/installer-exe/-/installer-exe-6.0.0-beta.47.tgz#4b41527f79da6a3f76299d9455ff2622fc5e76ac"
+  integrity sha512-1H54IlIDs+qB4+EnkrFShdBfLIezo236M16hQcBKhr2x+kj1WtIEy9cCHPkuO++XXattoGvWXG0sMKv4AWJSQw==
   dependencies:
-    "@electron-forge/installer-base" "6.0.0-beta.46"
+    "@electron-forge/installer-base" "6.0.0-beta.47"
     open "^7.0.0"
 
-"@electron-forge/installer-linux@6.0.0-beta.46":
-  version "6.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@electron-forge/installer-linux/-/installer-linux-6.0.0-beta.46.tgz#ad7de5b4695221f9ecf680c4fa17d499323faf58"
-  integrity sha512-3ZpmPScJGQdZN1kRHA4t7/ibiMbDm7s7YLbC88o+OUOFo2MjrZpN2jEGpEFh693VWh+YN2FF73PNuvDph9nkLQ==
+"@electron-forge/installer-linux@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/installer-linux/-/installer-linux-6.0.0-beta.47.tgz#3495e0c0bf6db2c83fb6aae1954e12f28fa3dca7"
+  integrity sha512-OVCGcYkLh7WfeZIkaEkKsglDQ8zY1Tbi2I70a4/5G/2TZ9+GboIQEs5AI+Nl8uCFaE2SGGIQtvOWsJe63T/Aow==
   dependencies:
-    "@electron-forge/installer-base" "6.0.0-beta.46"
+    "@electron-forge/installer-base" "6.0.0-beta.47"
     sudo-prompt "^9.1.1"
 
-"@electron-forge/installer-rpm@6.0.0-beta.46":
-  version "6.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@electron-forge/installer-rpm/-/installer-rpm-6.0.0-beta.46.tgz#e3ed24b7ce984bed9d1b3974d63ef27051ddb32d"
-  integrity sha512-0PsJrFs+GNHo0Nrx482misY/Ep8ziS9reSJcoPcRPGFP0rgZQGEpElXsmgYSRV9+fRX+OSBYEeRrDaDOzCkv/g==
+"@electron-forge/installer-rpm@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/installer-rpm/-/installer-rpm-6.0.0-beta.47.tgz#bff9fd2480115da50c64a6a11ad0e1fca87fd5f2"
+  integrity sha512-sS6w4EF8Qinacw0Dps8bHZJTZ6T5lEPsjF67wvLZEn9kNxtXWukptf3pqfNoJ3p/t6wsuFlsN0FLJwm3u01UOQ==
   dependencies:
-    "@electron-forge/installer-linux" "6.0.0-beta.46"
+    "@electron-forge/installer-linux" "6.0.0-beta.47"
 
-"@electron-forge/installer-zip@6.0.0-beta.46":
-  version "6.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@electron-forge/installer-zip/-/installer-zip-6.0.0-beta.46.tgz#db85cfd3e76cf366d39e9ba0bf13adffc1c095a4"
-  integrity sha512-byN6pK2PvdS7f/W4qdb7bmZquHRVLy34Xak1ACWLfTlOsASS3gAER1/oC2nte8B6PKdQXU7jeVzCg83pRYXVUg==
+"@electron-forge/installer-zip@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/installer-zip/-/installer-zip-6.0.0-beta.47.tgz#2a3f6c4052c4db37261cab2982998ec2e9f3f2e7"
+  integrity sha512-1MAyTypYcMPLmNr4Xr56OvCMPjpzFj6jYjFqGkcbNazkQkO1T6l1JSHQBvjWk8PMNPPnOFBWPVHvtE5PFMVKLg==
   dependencies:
-    "@electron-forge/installer-darwin" "6.0.0-beta.46"
+    "@electron-forge/installer-darwin" "6.0.0-beta.47"
     cross-spawn-promise "^0.10.1"
     fs-extra "^8.1.0"
 
-"@electron-forge/maker-base@6.0.0-beta.46":
-  version "6.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@electron-forge/maker-base/-/maker-base-6.0.0-beta.46.tgz#6edbe8708db2ac3cab0713d4b05ebc60257c9705"
-  integrity sha512-KDSuARGv3b3mYPFfHfqSTQ0+hGyfDoJAxudHO5rEvnhq3TumF2sZozL3556ryEsNRq2NhRapB3vOwZlCu0Vaeg==
+"@electron-forge/maker-base@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/maker-base/-/maker-base-6.0.0-beta.47.tgz#a8ce70cf41cfa2dafaa5bd12d201cb2589ca8b4f"
+  integrity sha512-iGaxOmN80rN9SNZJRiyHFHgMTrtfJcapoW7TUj26DFpi+cd2NCg57z45Rzp2cdJd+iZvS15B9eZn3MVxaxKIvA==
   dependencies:
-    "@electron-forge/shared-types" "6.0.0-beta.46"
+    "@electron-forge/shared-types" "6.0.0-beta.47"
     fs-extra "^8.1.0"
     which "^2.0.2"
 
-"@electron-forge/plugin-base@6.0.0-beta.46":
-  version "6.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@electron-forge/plugin-base/-/plugin-base-6.0.0-beta.46.tgz#a76ad57d37f1c90e6c2eb188541586c978991675"
-  integrity sha512-n2qewmyXUlrO6n+y48CXtmdpt/drVbCPI0MgeJby6M66PkiKntuvMiu8cYqhEie+zQZcI845+5M2ka6wMtFNBA==
+"@electron-forge/plugin-base@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/plugin-base/-/plugin-base-6.0.0-beta.47.tgz#24458bd75d9d4657c5312d5972805ddd835523c9"
+  integrity sha512-xAcuj54+S4NlPC3d1RpJa7k2VOQ4wCamERAwO34Se3/U/wGh5q0heHh4+EXG18/FfiwL8zzZgx9E0N0wZqFtMA==
   dependencies:
-    "@electron-forge/shared-types" "6.0.0-beta.46"
+    "@electron-forge/shared-types" "6.0.0-beta.47"
 
-"@electron-forge/publisher-base@6.0.0-beta.46":
-  version "6.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@electron-forge/publisher-base/-/publisher-base-6.0.0-beta.46.tgz#2e2229ae970bbec7a1d95501b4b0426940949217"
-  integrity sha512-BYSC6t020zTqxLPvsp0DrflIRUM3MBfCb38NmmQzropJIYWEch7IfMF0RYX1EDDeqwiv+rsaSc2uwWXHYj3gqw==
+"@electron-forge/publisher-base@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/publisher-base/-/publisher-base-6.0.0-beta.47.tgz#695eeaaa3a02283cc43c66d63d21f3da88b5c873"
+  integrity sha512-yNFtyrUtbSjfBWZWvCcRvim5dhBQjlG4q5xlC2PcUWPHYUQfLVQRYTSXT3A/nwdlq1Fa7Vjf9sB0yBZgn25NYg==
 
-"@electron-forge/shared-types@6.0.0-beta.46":
-  version "6.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@electron-forge/shared-types/-/shared-types-6.0.0-beta.46.tgz#bd35a04800698353cbe6616289ac26e18d9c4e91"
-  integrity sha512-gKlxOg3rAqCwsPJBI+be77CIhmhggjJiOuxeB9uz8k35//GvhLkfszulHLHAyzAWmuEtcAIYwKtoUrVA9h25mg==
+"@electron-forge/shared-types@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/shared-types/-/shared-types-6.0.0-beta.47.tgz#64222876d62b49d25b6b0abfd52a62d058da939d"
+  integrity sha512-bD2bId56tuqhVzPRDEGaS4Qw4K/AFleftstznQOmkBDpBG3R+roN4y35kiiZ7aVu3ymzzFQ414Kh5s9MwBKHPw==
   dependencies:
-    "@electron-forge/async-ora" "6.0.0-beta.46"
+    "@electron-forge/async-ora" "6.0.0-beta.47"
     "@types/electron-packager" "^14.0.0"
     electron-rebuild "^1.8.6"
     ora "^4.0.3"
 
-"@electron-forge/template-webpack@6.0.0-beta.46":
-  version "6.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@electron-forge/template-webpack/-/template-webpack-6.0.0-beta.46.tgz#763f10cd3228d10186f2c6be38475660e9fe874c"
-  integrity sha512-OngeEtK0Wi9IX0B+hvk11LTv2Kf+Ezm7Tgrjl8zQFLQ1pvzpe9DzLMKMHuDaK/ejHijZ1WkQiRDbW4dZ4tZaNA==
+"@electron-forge/template-base@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/template-base/-/template-base-6.0.0-beta.47.tgz#bc785eefb4545d972987e96665fcef2845ddf0af"
+  integrity sha512-7WGLGcDTYv8i+Mme5KAIdQy/XmI+aU8DxSHvZxWkCh/JWo99CAzmHJOoDJqlJDA4aB43XPT6T+KqiDGcKykfWw==
   dependencies:
-    "@electron-forge/async-ora" "6.0.0-beta.46"
-    "@electron-forge/shared-types" "6.0.0-beta.46"
+    "@electron-forge/async-ora" "6.0.0-beta.47"
+    "@electron-forge/shared-types" "6.0.0-beta.47"
+    debug "^4.1.0"
+    fs-extra "^8.1.0"
+    username "^5.1.0"
+
+"@electron-forge/template-typescript-webpack@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/template-typescript-webpack/-/template-typescript-webpack-6.0.0-beta.47.tgz#6b0fb7cb4b01fb06b3de91d87066cc92b31712b0"
+  integrity sha512-WYC9yQrflrKM+GE8LeqxEfT7fxwSgqSeXFj+7JTB5S4308uaDkc3vmnhR0sK8UV5AJmKEG77hH9QdRV9g132/Q==
+  dependencies:
+    "@electron-forge/async-ora" "6.0.0-beta.47"
+    "@electron-forge/shared-types" "6.0.0-beta.47"
+    "@electron-forge/template-base" "6.0.0-beta.47"
+    fs-extra "^8.1.0"
+
+"@electron-forge/template-typescript@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/template-typescript/-/template-typescript-6.0.0-beta.47.tgz#6a0c67989216b9f0b97854c85f33b315c1c48854"
+  integrity sha512-waZjZcdjVWXJYWPzJBLyjXN4rzK2jgEIfOcoWzIgZ3jTzCDWsUABi82FhX/s3VtlfrSQcvQp1zLFYfM2LC8qdg==
+  dependencies:
+    "@electron-forge/async-ora" "6.0.0-beta.47"
+    "@electron-forge/shared-types" "6.0.0-beta.47"
+    "@electron-forge/template-base" "6.0.0-beta.47"
+    fs-extra "^8.1.0"
+
+"@electron-forge/template-webpack@6.0.0-beta.47":
+  version "6.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@electron-forge/template-webpack/-/template-webpack-6.0.0-beta.47.tgz#1a20531ea06271918b75fb4eca35fba81454ffa4"
+  integrity sha512-/xrm6AZauTyFQCGPdNG+/uuJ1CoHTL+HG9YgBKhmrAv1k7HSCfrt36bKOu+hX0YJHkXOyBPHICDbGjLQBzwS+A==
+  dependencies:
+    "@electron-forge/async-ora" "6.0.0-beta.47"
+    "@electron-forge/shared-types" "6.0.0-beta.47"
+    "@electron-forge/template-base" "6.0.0-beta.47"
     fs-extra "^8.1.0"
 
 "@electron/get@^1.3.1", "@electron/get@^1.6.0":


### PR DESCRIPTION
Update to the new template interface in beta.47 and pin the version so our tests don't fail when forge makes a blueprint-breaking change (should be able to un-pin when forge is out of beta).