### PR TITLE
Restore require() sooner

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,14 @@ module.exports = {
     };
   },
 
+  included(app) {
+    this._super.included.apply(this, arguments);
+
+    app.import('vendor/wrap-require.js', {
+      type: 'vendor',
+    });
+  },
+
   contentFor(type) {
     const { env: { EMBER_CLI_ELECTRON } } = process;
 

--- a/lib/resources/shim-footer.js
+++ b/lib/resources/shim-footer.js
@@ -1,25 +1,6 @@
 // ember-electron
 ((win) => {
-  const { requireNode, require: requireAMD } = win;
-
-  // Redefine a global `require` function that can satisfy both Node and AMD module systems.
-  if (requireAMD) {
-    win.require = (...args) => {
-      try {
-        return requireAMD(...args);
-      } catch(error) {
-        if (error.toString().includes('Error: Could not find module')) {
-          return requireNode(...args);
-        }
-
-        console.error(error); // eslint-disable-line no-console
-      }
-    };
-  } else {
-    win.require = requireNode;
-  }
-
-  // Restore others
+  // Restore process and module
   win.process = win.processNode;
   win.module = win.moduleNode;
 })(window);

--- a/vendor/wrap-require.js
+++ b/vendor/wrap-require.js
@@ -1,0 +1,26 @@
+// ember-electron
+((win) => {
+  const { requireNode, require: requireAMD } = win;
+
+  // Redefine a global `require` function that can satisfy both Node and AMD module systems.
+  if (requireAMD) {
+    win.require = (...args) => {
+      try {
+        return requireAMD(...args);
+      } catch(error) {
+        if (error.toString().includes('Error: Could not find module')) {
+          return requireNode(...args);
+        }
+
+        console.error(error); // eslint-disable-line no-console
+      }
+    };
+
+    // Both Ember's and Node's require() have some properties (e.g. Ember's has
+    // require.has() and Node's has require.resolve()). Fortunately there are no
+    // naming conflicts, so we can expose them all.
+    Object.assign(win.require, requireNode, requireAMD);
+  } else {
+    win.require = requireNode;
+  }
+})(window);


### PR DESCRIPTION
In complicated ember-auto-import/webpack scenarios where the desire is for webpacked modules to be able to require() node modules, setting up our require() wrapper in shim-footer.js might be too late, so set up the wrapper sooner -- in vendor.js. It will still be after Ember has loaded, so it won't interfere with Ember setting up its module loader.