### PR TITLE
Fix making/building with a custom output path

### DIFF
--- a/forge/template.js
+++ b/forge/template.js
@@ -7,7 +7,8 @@ const rimraf = promisify(require('rimraf'));
 const ncp = promisify(require('ncp'));
 const {
   emberBuildDir,
-  emberTestBuildDir
+  emberTestBuildDir,
+  packageOutDir
 } = require('../lib/utils/build-paths');
 
 async function updateGitIgnore(dir) {
@@ -19,6 +20,14 @@ async function updateGitIgnore(dir) {
     '# Ember build',
     `${emberBuildDir}/`,
     `${emberTestBuildDir}/`,
+    // `electron-packager` will automatically ignore the output directory, but
+    // if someone were to build once without specifying a custom output path,
+    // and then build with a custom output path, during the second build,
+    // `electron-packager` would only ignore the custom output path, and not the
+    // contents of `packageDir`, so it would package up all that previously
+    // built content in the second packaged application.
+    '# package/make output directory',
+    `${packageOutDir}/`,
     ''
   ].join('\n'));
 }


### PR DESCRIPTION
If a user were to run `ember electron:package` or `ember electron:make` and then run either command again with a custom output path using `--output-path`, the second application package would end up including all the built assets from the first one, inflating it's size massively. This sorta fixes that -- see comment in code for more info.