### PR TITLE
Set `contextIsolation` to false for tests

### DIFF
--- a/lib/test-support/index.js
+++ b/lib/test-support/index.js
@@ -35,6 +35,7 @@ function openTestWindow(emberAppDir) {
     height: 600,
     webPreferences: {
       backgroundThrottling: false,
+      contextIsolation: false,
       nodeIntegration: true
     }
   });


### PR DESCRIPTION
Not sure if we want this false or true, but it needs to be set to something.