### PR TITLE
fix: replace deprecated 'crashed' event

### DIFF
--- a/forge/files/src/index.js
+++ b/forge/files/src/index.js
@@ -63,9 +63,7 @@ app.on('ready', async () => {
     if (details.reason === 'killed' || details.reason === 'clean-exit') {
       return;
     }
-    console.log('Your Ember app (or other code) in the main window has crashed.');
-    console.log('This is a serious issue that needs to be handled and/or debugged.');
-    console.log('Reason: ' + details.reason);
+    console.log('Your main window process has exited unexpectedly -- see https://www.electronjs.org/docs/api/web-contents#event-render-process-gone');
   });
 
   mainWindow.on('unresponsive', () => {

--- a/forge/files/src/index.js
+++ b/forge/files/src/index.js
@@ -59,9 +59,13 @@ app.on('ready', async () => {
     mainWindow.loadURL(emberAppURL);
   });
 
-  mainWindow.webContents.on('crashed', () => {
+  mainWindow.webContents.on('render-process-gone', (_event, details) => {
+    if (details.reason === 'killed' || details.reason === 'clean-exit') {
+      return;
+    }
     console.log('Your Ember app (or other code) in the main window has crashed.');
     console.log('This is a serious issue that needs to be handled and/or debugged.');
+    console.log('Reason: ' + details.reason);
   });
 
   mainWindow.on('unresponsive', () => {

--- a/forge/files/src/index.js
+++ b/forge/files/src/index.js
@@ -64,6 +64,7 @@ app.on('ready', async () => {
       return;
     }
     console.log('Your main window process has exited unexpectedly -- see https://www.electronjs.org/docs/api/web-contents#event-render-process-gone');
+    console.log('Reason: ' + details.reason);
   });
 
   mainWindow.on('unresponsive', () => {


### PR DESCRIPTION
Basically 'crashed' is deprecated: https://www.electronjs.org/docs/api/web-contents#event-crashed-deprecated