### PR TITLE
fix: following #676 to set contextIsolation explicitly

### DIFF
--- a/forge/files/src/index.js
+++ b/forge/files/src/index.js
@@ -45,6 +45,10 @@ app.on('ready', async () => {
   mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
+    webPreferences: {
+      // Details about what this is https://github.com/electron/electron/blob/master/docs/tutorial/context-isolation.md
+      contextIsolation: false,
+    },
   });
 
   // If you want to open up dev tools programmatically, call


### PR DESCRIPTION
See https://github.com/electron/electron/issues/23506

Decided to keep this false because of #676, but I think it should be true and now might be the time for that since it's still a beta.