### PR TITLE
Make embroider-compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "dependencies": {
     "@electron-forge/core": "6.0.0-beta.54",
-    "broccoli-string-replace": "^0.1.2",
     "chalk": "^4.0.0",
     "debug": "^4.1.1",
     "ember-cli-babel": "^7.23.0",

--- a/tests/dummy/app/templates/docs/faq/routing-and-asset-loading.md
+++ b/tests/dummy/app/templates/docs/faq/routing-and-asset-loading.md
@@ -40,7 +40,7 @@ For `app.js` and other scripts and CSS loaded out of `index.html`, we have a nic
 rootURL: process.env.EMBER_CLI_ELECTRON ? '' : '/',
 ```
 
-There is an additional wrinkle when running tests. Since Ember puts the `index.html` used for tests at `tests/index.html`, it actually needs assets paths that look like `../assets/app.js`. However, `ember-cli` ([clean-base-url](https://github.com/ember-cli/clean-base-url) actually) forces a non-empty `rootURL` to start with `/`, so `ember-electron` uses the broccoli pipeline to modify these URLs in `tests/index.html` to start with `../`.
+There is an additional wrinkle when running tests. Since Ember puts the `index.html` used for tests at `tests/index.html`, it actually needs assets paths that look like `../assets/app.js`. However, `ember-cli` ([clean-base-url](https://github.com/ember-cli/clean-base-url) actually) forces a non-empty `rootURL` to start with `/`, so `ember-electron` injects a `<base src="..">` element into `tests/index.html` to fix asset loading.
 
 ### Other assets (images, fonts, etc.)
 


### PR DESCRIPTION
We can't use the postprocessTree() hook anymore, so fix the asset URLs by adding a `<base href="..">` element via the `contentFor()` hook, and make testem work by writing a new `<script>` tag with the working `testem.js` URL, leaving the exists one in place harmlessly no-op'ing.