### PR TITLE
Increase yarn timeout in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: volta-cli/action@v1
         with:
           node-version: 10.x
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile --network-timeout 100000
 
       - name: 'Lint'
         run: |
@@ -37,7 +37,7 @@ jobs:
       - uses: volta-cli/action@v1
         with:
           node-version: 10.x
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile --network-timeout 100000
 
       - name: 'Basic Tests'
         run: yarn test-fast
@@ -56,7 +56,7 @@ jobs:
       - uses: volta-cli/action@v1
         with:
           node-version: 10.x
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile --network-timeout 100000
 
       - name: 'End-to-end Tests (${{ matrix.package-manager }})'
         uses: GabrielBB/xvfb-action@v1


### PR DESCRIPTION
We're getting intermittent timeouts installing dependencies on MacOS, and various issues such as https://github.com/yarnpkg/yarn/issues/6115 indicate that it's likely some kind of network and/or disk I/O (maybe virus/anti-malware) issue, so let's bump up the install timeout.