### PR TITLE
Enable remote module in tests

### DIFF
--- a/lib/test-support/index.js
+++ b/lib/test-support/index.js
@@ -37,6 +37,7 @@ function openTestWindow(emberAppDir) {
       backgroundThrottling: false,
       contextIsolation: false,
       nodeIntegration: true,
+      enableRemoteModule: true,
     },
   });
 


### PR DESCRIPTION
In Electron v10 it defaults to false, so enable it for tests like we do with nodeIntegration, etc.