### PR TITLE
Use process.execPath is the test runner

### DIFF
--- a/lib/test-runner.js
+++ b/lib/test-runner.js
@@ -20,7 +20,7 @@
 //
 
 module.exports = {
-  exe: 'node',
+  exe: process.execPath,
   // These arguments are used in `lib/test-support/index.js`, which is called
   // from the test main process (via the blueprint-generated
   // `electron-app/tests/index.js`)


### PR DESCRIPTION
Use process.execPath instead of 'node' so we use the same Node executable that is running ember-cli, rather than rely on the user's PATH to point to the right (or any) version of Node.

Thanks @rwjblue for pointing this out

Fixes #750