### PR TITLE
fix: inject relative asset paths #914

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 function injectScript(scriptName) {
-  return `<script src="/ember-electron/${scriptName}"></script>`;
+  return `<script src="ember-electron/${scriptName}"></script>`;
 }
 
 module.exports = {


### PR DESCRIPTION
windows seems to get confused when using absolute paths