### PR TITLE
Fix build failure from chalk dependency caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "dependencies": {
     "@electron-forge/core": "6.0.0-beta.61",
-    "chalk": "^4.0.0",
     "debug": "^4.1.1",
     "ember-cli-babel": "^7.23.0",
     "execa": "^5.0.0",
@@ -124,6 +123,7 @@
     "tmp": "^0.2.1"
   },
   "peerDependencies": {
+    "chalk": "*",
     "ember-cli": "^3.4.0",
     "ember-cli-dependency-checker": "^3.1.0"
   },


### PR DESCRIPTION
An ongoing issue with `ember-cli` is that when you run `ember install`, it runs a node process that first runs `yarn add`/`npm install`, which modified `node_modules` "under" the running process, and then calls into blueprint code. This means that in certain scenarios, `ember-cli` might require a module that is later moved by the yarn/npm hoisting. If the blueprint (or really anything else in the node process) tries to require such a package, node can get extremely confused because it is not tooled to tolerate modules moving around while a process is running.

Really, `ember-cli` should run the blueprint code in a separate process to avoid this, but for now it's a pitfall we have to deal with. In our case, the above was happening to `chalk`, causing build failures. We could pin `chalk` to the same version as `ember-cli`'s so that it _shouldn't_ be moved around during the install, but if/when `ember-cli` upgrades its `chalk` dependency, wouldn't be able to support versions both before and after the upgrade. So I think the best option here is to make `chalk` a `peerDependency`, so we just use whatever version is around. Our use of `chalk` is pretty basic, and they seem unlikely to make breaking changes the APIs we use, so I think there's minimal risk that a new version of `chalk` will break our world.

If this continues to be an issue, we can perhaps explore just removing our `chalk` dependency and writing our own code for formatting messages in the console, although that would be its own kind of bummer.