### PR TITLE
Remove travis.yml updating in favor of docs

### DIFF
--- a/node-tests/acceptance/end-to-end-test.js
+++ b/node-tests/acceptance/end-to-end-test.js
@@ -116,15 +116,6 @@ describe('end-to-end', function () {
       });
 
       runTests();
-
-      it('the blueprint updated .travis.yml', function () {
-        let travisYml = readFileSync('.travis.yml').toString();
-        expect(travisYml).to.include('cd electron-app && yarn');
-        expect(travisYml).to.include(`export DISPLAY=':99.0'`);
-        expect(travisYml).to.include(
-          'Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &'
-        );
-      });
     });
   }
 
@@ -170,16 +161,6 @@ describe('end-to-end', function () {
       });
 
       runTests();
-
-      it('the blueprint updated .travis.yml', function () {
-        let travisYml = readFileSync('.travis.yml').toString();
-        expect(travisYml).to.include('npm install');
-        expect(travisYml).to.include('cd electron-app && npm install');
-        expect(travisYml).to.include(`export DISPLAY=':99.0'`);
-        expect(travisYml).to.include(
-          'Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &'
-        );
-      });
     });
   }
 

--- a/node-tests/unit/blueprint-test.js
+++ b/node-tests/unit/blueprint-test.js
@@ -65,47 +65,4 @@ describe('blueprint', function () {
       expect(ENV.locationType).to.equal('hash');
     });
   });
-
-  describe('update travis.yml', function () {
-    function normalizeYaml(content) {
-      let lines = content.split('\n');
-      // filter out empty lines because we don't care about empty-line differences
-      lines = lines.filter((line) => line.trim());
-      // remove \r's in case we're on windows and they were added
-      lines = lines.map((line) => line.replace('\r', ''));
-      return lines.join('\n');
-    }
-
-    async function runTest(fixtureName) {
-      let fixtureDir = path.join(
-        __dirname,
-        '..',
-        'fixtures',
-        'travis-yml',
-        fixtureName
-      );
-
-      copyFileSync(path.join(fixtureDir, '.travis.yml'), '.travis.yml');
-      await blueprint.updateTravisYml();
-      let expected = readFileSync('.travis.yml').toString();
-      let actual = readFileSync(
-        path.join(fixtureDir, 'expected.yml')
-      ).toString();
-
-      expect(normalizeYaml(actual)).to.equal(normalizeYaml(expected));
-    }
-
-    it('works with yarn', async function () {
-      writeFileSync('yarn.lock', '');
-      await runTest('yarn');
-    });
-
-    it('works with npm', async function () {
-      await runTest('npm');
-    });
-
-    it('works with npm with custom install section', async function () {
-      await runTest('npm-custom-install');
-    });
-  });
 });


### PR DESCRIPTION
This was failing with latest ember-cli, since they moved to github actions. Rather than keep up with all CI changes, we'll document and let users update their own builds.