### PR TITLE
Run blueprint manually

### DIFF
--- a/blueprints/ember-electron-postinstall/index.js
+++ b/blueprints/ember-electron-postinstall/index.js
@@ -1,0 +1,19 @@
+const Blueprint = require('ember-cli/lib/models/blueprint');
+
+module.exports = class EmberElectronBlueprint extends Blueprint {
+  constructor(options) {
+    super(options);
+
+    this.description = 'Instructions for post-install ember-electron setup.';
+  }
+
+  normalizeEntityName(entityName) {
+    return entityName;
+  }
+
+  async afterInstall() {
+    this.ui.writeLine(
+      `\nRun 'ember g ember-electron' to complete ember-electron setup\n`
+    );
+  }
+};

--- a/node-tests/acceptance/end-to-end-test.js
+++ b/node-tests/acceptance/end-to-end-test.js
@@ -101,14 +101,18 @@ describe('end-to-end', function () {
           '--yarn',
           '--skip-git',
           '--no-welcome'
-        ).then(() => {
-          process.chdir('ee-test-app');
+        )
+          .then(() => {
+            process.chdir('ee-test-app');
 
-          return ember(
-            'install',
-            `ember-electron@${path.join(packageTmpDir, 'package')}`
-          );
-        });
+            return ember(
+              'install',
+              `ember-electron@${path.join(packageTmpDir, 'package')}`
+            );
+          })
+          .then(() => {
+            return ember('g', 'ember-electron');
+          });
       });
 
       after(() => {
@@ -132,28 +136,32 @@ describe('end-to-end', function () {
           'false',
           '--skip-git',
           '--no-welcome'
-        ).then(() => {
-          process.chdir('ee-test-app');
-          // For some reason, either ember-cli-dependency-checker isn't working with npm
-          // or npm isn't getting the right version because without this env var (or hacking package.json)
-          // we get:
-          //     Missing npm packages:
-          //     Package: ember-electron
-          //       * Specified: file:../../tmp-230055rygYPzwOs0w/ember-electron-cachebust.tar
-          //       * Installed: file:/tmp/tmp-230055rygYPzwOs0w/ember-electron-cachebust.tar
-          //
-          //     Run `npm install` to install missing dependencies.
-          process.env.SKIP_DEPENDENCY_CHECKER = true;
+        )
+          .then(() => {
+            process.chdir('ee-test-app');
+            // For some reason, either ember-cli-dependency-checker isn't working with npm
+            // or npm isn't getting the right version because without this env var (or hacking package.json)
+            // we get:
+            //     Missing npm packages:
+            //     Package: ember-electron
+            //       * Specified: file:../../tmp-230055rygYPzwOs0w/ember-electron-cachebust.tar
+            //       * Installed: file:/tmp/tmp-230055rygYPzwOs0w/ember-electron-cachebust.tar
+            //
+            //     Run `npm install` to install missing dependencies.
+            process.env.SKIP_DEPENDENCY_CHECKER = true;
 
-          return ember(
-            'install',
-            `ember-electron@${path.join(
-              packageTmpDir,
-              'ember-electron-cachebust.tar'
-            )}`,
-            '--no-yarn'
-          );
-        });
+            return ember(
+              'install',
+              `ember-electron@${path.join(
+                packageTmpDir,
+                'ember-electron-cachebust.tar'
+              )}`,
+              '--no-yarn'
+            );
+          })
+          .then(() => {
+            return ember('g', 'ember-electron');
+          });
       });
 
       after(() => {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@electron-forge/core": "6.0.0-beta.61",
+    "chalk": "^4.1.2",
     "debug": "^4.1.1",
     "ember-cli-babel": "^7.23.0",
     "execa": "^5.0.0",
@@ -122,7 +123,6 @@
     "tmp": "^0.2.1"
   },
   "peerDependencies": {
-    "chalk": "*",
     "ember-cli": "^3.4.0",
     "ember-cli-dependency-checker": "^3.1.0"
   },
@@ -136,7 +136,7 @@
     "edition": "octane"
   },
   "ember-addon": {
-    "defaultBlueprint": "ember-electron",
+    "defaultBlueprint": "ember-electron-postinstall",
     "versionCompatibility": {
       "ember": ">=2.3.0"
     },

--- a/tests/dummy/app/templates/docs/guides/installation.md
+++ b/tests/dummy/app/templates/docs/guides/installation.md
@@ -6,7 +6,10 @@
 
 ```sh
 ember install ember-electron
+ember g ember-electron
 ```
+
+(manually running the blueprint is currently necessary because of [this issue](https://github.com/ember-cli/ember-cli/issues/7431) in `ember-cli`)
 
 This will install `ember-electron` and create and initialize an [electron-forge](https://www.electronforge.io/) project in the `electron-app` directory inside your Ember app. Then you can run `ember electron` to launch your app in Electron.
 

--- a/tests/dummy/app/templates/docs/guides/upgrading.md
+++ b/tests/dummy/app/templates/docs/guides/upgrading.md
@@ -7,6 +7,7 @@ While upgrading from 2.x to 3.x should not be very time-consuming in most cases,
 ```sh
 yarn-or-npm remove ember-electron
 ember install ember-electron
+ember g ember-electron
 ```
 
 When prompted to overwrite `testem-electron.js`, choose `yes`.


### PR DESCRIPTION
Unfortunately #1048 wasn't a full fix because `electron-forge` also has a dependency on `chalk`, so even without our own dependency, installing `ember-electron` could cause the hoisting to change triggering the underlying issue (https://github.com/ember-cli/ember-cli/issues/7431).

So, until that issue in `ember-cli` can be addressed, we're no longer running the blueprint automatically. Instead, we point the default blueprint at a new one that simply prints out instructions telling the user to run `ember g ember-electron` manually.