### PR TITLE
Require node >= 14.17.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,6 @@ on:
     tags:
       - v*
     
-    
 jobs:
   lint:
     name: Lint
@@ -16,8 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
-        with:
-          node-version: 12.x
       - run: yarn install --frozen-lockfile --network-timeout 100000
 
       - name: 'Lint'
@@ -35,8 +32,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
-        with:
-          node-version: 12.x
       - run: yarn install --frozen-lockfile --network-timeout 100000
 
       - name: 'Basic Tests'
@@ -54,8 +49,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
-        with:
-          node-version: 12.x
       - run: yarn install --frozen-lockfile --network-timeout 100000
 
       - name: 'End-to-end Tests (${{ matrix.package-manager }})'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Compatibility
 
 * Ember.js v3.24 or above
 * Ember CLI v3.24 or above
-* Node.js v12 or above
+* Node.js v14.17.5 or above
 
 Documentation
 ------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "ember-cli-dependency-checker": ">= 3.1.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": ">= 14.17.5 || >= 16"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
@@ -163,7 +163,7 @@
     }
   },
   "volta": {
-    "node": "12.22.1",
-    "yarn": "1.22.10"
+    "node": "14.20.0",
+    "yarn": "1.22.19"
   }
 }


### PR DESCRIPTION
electron-forge requires node 14.17.5 and several other packages are requiring 14.x, so this hopefully makes us compatible.