### PR TITLE
Un-pin electron forge

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test-slow": "mocha node-tests/acceptance/**/*.js"
   },
   "dependencies": {
-    "@electron-forge/core": "6.0.5",
+    "@electron-forge/core": "^6.0.5",
     "chalk": "^4.1.2",
     "debug": "^4.1.1",
     "ember-cli-babel": "^7.26.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1062,7 +1062,7 @@
     semver "^7.2.1"
     yarn-or-npm "^3.0.1"
 
-"@electron-forge/core@6.0.5":
+"@electron-forge/core@^6.0.5":
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/@electron-forge/core/-/core-6.0.5.tgz#38e8ee4e1f5bbf22934b02b3d202e19dcb2b055f"
   integrity sha512-lMtm3x2ZFEBOU7/JTIo2oI5dXm2hKqpdc4opHA7iOxja5YYDDvnqKt+tACJSCdnCOxYLS+0OSoaz/DJ8SNyStw==


### PR DESCRIPTION
Probably as a leftover from when it was in beta, the `@electron-forge/core` dependency was pinned. Apparently `@electron-forge/template-base@6.0.5` doesn't work with `@electron-forge/core@6.0.4` (but core's dependency on template-base isn't pinned), so when installing `ember-electron` apps would end up with core v6.0.4 and template-base v6.0.5 and the blueprint wouldn't run. Un-pinning core should prevent this from happening again.

Fixes #1390