### PR TITLE
Add option to skip Ember build

### DIFF
--- a/lib/commands/electron.js
+++ b/lib/commands/electron.js
@@ -38,6 +38,12 @@ module.exports = BaseCommand.extend({
       aliases: ['lrprefix'],
       description: 'Default to _lr',
     },
+    {
+      name: 'skip-ember-build',
+      type: Boolean,
+      default: false,
+      description: 'Skip starting the Ember server and only start Electron'
+    },
   ],
 
   async run(commandOptions) {

--- a/lib/tasks/electron.js
+++ b/lib/tasks/electron.js
@@ -13,49 +13,57 @@ const { api } = require('../utils/forge-core');
 class ElectronTask extends Task {
   async run(options) {
     let { ui } = this;
+    let { environment, skipEmberBuild } = options;
 
-    ui.startProgress(chalk.green('Building'), chalk.green('.'));
+    if (skipEmberBuild) {
+      ui.writeLine(chalk.green('Skipping build...'))
+    } else {
+      ui.startProgress(chalk.green('Building'), chalk.green('.'));
+    }
 
-    let builder = new Builder({
+    let builder = skipEmberBuild ? null : new Builder({
       ui,
       outputPath: emberBuildPath,
-      environment: options.environment,
+      environment,
       project: this.project,
     });
 
-    ui.writeLine(`Environment: ${options.environment}`);
+    ui.writeLine(`Environment: ${environment}`);
 
-    let watcher;
-    // The watcher API changed in ember-cli@4.9, so we need some compat code
-    if (Watcher.build) {
-      // ember-cli >= 4.9
-      watcher = (
-        await Watcher.build({
+    if (!skipEmberBuild) {
+      let watcher;
+      // The watcher API changed in ember-cli@4.9, so we need some compat code
+      if (Watcher.build) {
+        // ember-cli >= 4.9
+        watcher = (
+          await Watcher.build({
+            ui,
+            builder,
+            analytics: this.analytics,
+            options,
+          })
+        ).watcher;
+      } else {
+        // ember-cli < 4.9
+        watcher = new Watcher({
           ui,
           builder,
           analytics: this.analytics,
           options,
-        })
-      ).watcher;
-    } else {
-      // ember-cli < 4.9
-      watcher = new Watcher({
-        ui,
-        builder,
+        });
+      }
+
+      let expressServer = new ExpressServer({
+        ui: this.ui,
+        project: this.project,
         analytics: this.analytics,
-        options,
+        watcher,
+        serverRoot: './server',
       });
+
+      await Promise.all([expressServer.start(options), watcher]);
     }
 
-    let expressServer = new ExpressServer({
-      ui: this.ui,
-      project: this.project,
-      analytics: this.analytics,
-      watcher,
-      serverRoot: './server',
-    });
-
-    await Promise.all([expressServer.start(options), watcher]);
     await this._runElectron(builder, options);
   }
 
@@ -96,7 +104,7 @@ class ElectronTask extends Task {
       });
     });
 
-    await builder.cleanup();
+    await builder?.cleanup();
   }
 }
 


### PR DESCRIPTION
Sometimes all I want to do is compile our native modules and run the app, without serving / rebuilding Ember (which takes forever)