### PR TITLE
Use absolute path

### DIFF
--- a/lib/tasks/make.js
+++ b/lib/tasks/make.js
@@ -4,6 +4,7 @@ const chalk = require('chalk');
 const Task = require('ember-cli/lib/models/task');
 const { electronProjectPath } = require('../utils/build-paths');
 const { api } = require('../utils/forge-core');
+const path = require('path');
 
 //
 // A task that runs electron-forge make to make installers. The skipPackage
@@ -18,7 +19,7 @@ class MakeTask extends Task {
     ui.writeLine(chalk.green('Making Electron project.'));
 
     let makeOptions = {
-      dir: electronProjectPath,
+      dir: path.resolve(electronProjectPath),
       outDir: outputPath,
       skipPackage,
     };

--- a/lib/tasks/package.js
+++ b/lib/tasks/package.js
@@ -4,6 +4,7 @@ const chalk = require('chalk');
 const Task = require('ember-cli/lib/models/task');
 const { electronProjectPath } = require('../utils/build-paths');
 const { api } = require('../utils/forge-core');
+const path = require('path');
 
 //
 // A task that runs electron-forge package to package the app.
@@ -16,7 +17,7 @@ class PackageTask extends Task {
     ui.writeLine(chalk.green('Packaging Electron project.'));
 
     let packageOptions = {
-      dir: electronProjectPath,
+      dir: path.resolve(electronProjectPath),
       outDir: outputPath,
     };
     if (platform) {

--- a/lib/tasks/publish.js
+++ b/lib/tasks/publish.js
@@ -4,6 +4,7 @@ const chalk = require('chalk');
 const Task = require('ember-cli/lib/models/task');
 const { electronProjectPath } = require('../utils/build-paths');
 const { api } = require('../utils/forge-core');
+const path = require('path');
 
 //
 // A task that runs electron-forge publish to publish artifacts.
@@ -16,7 +17,7 @@ class PublishTask extends Task {
     ui.writeLine(chalk.green('Publish Electron project.'));
 
     let publishOptions = {
-      dir: electronProjectPath,
+      dir: path.resolve(electronProjectPath),
       makeResults,
       publishTargets,
     };

--- a/node-tests/integration/commands/electron-test.js
+++ b/node-tests/integration/commands/electron-test.js
@@ -121,7 +121,7 @@ describe('electron command', function () {
     expect(DependencyChecker.prototype.checkDependencies).to.be.calledOnce;
   });
 
-  it('passes the correct path to electron-forge', async function () {
+  it('passes the correct (resolved) path to electron-forge', async function () {
     await expect(command.validateAndRun([])).to.be.fulfilled;
     expect(api.start).to.be.calledOnce;
     expect(api.start.firstCall.args[0].dir).to.equal(

--- a/node-tests/integration/commands/make-test.js
+++ b/node-tests/integration/commands/make-test.js
@@ -47,7 +47,7 @@ describe('electron:make command', function () {
     );
     expect(api.make).to.be.calledOnce;
     expect(api.make.firstCall.args[0]).to.deep.equal({
-      dir: 'electron-app',
+      dir: path.resolve('electron-app'),
       outDir: path.join('electron-app', 'out'),
       skipPackage: false,
     });
@@ -84,7 +84,7 @@ describe('electron:make command', function () {
     expect(buildTaskStub).to.not.be.called;
     expect(api.make).to.be.calledOnce;
     expect(api.make.firstCall.args[0]).to.deep.equal({
-      dir: 'electron-app',
+      dir: path.resolve('electron-app'),
       outDir: path.join('electron-app', 'out'),
       skipPackage: false,
     });
@@ -95,7 +95,7 @@ describe('electron:make command', function () {
     expect(buildTaskStub).to.not.be.called;
     expect(api.make).to.be.calledOnce;
     expect(api.make.firstCall.args[0]).to.deep.equal({
-      dir: 'electron-app',
+      dir: path.resolve('electron-app'),
       outDir: path.join('electron-app', 'out'),
       skipPackage: true,
     });
@@ -106,7 +106,7 @@ describe('electron:make command', function () {
     expect(buildTaskStub).to.not.be.called;
     expect(api.make).to.be.calledOnce;
     expect(api.make.firstCall.args[0]).to.deep.equal({
-      dir: 'electron-app',
+      dir: path.resolve('electron-app'),
       outDir: path.join('electron-app', 'out'),
       skipPackage: true,
     });
@@ -125,7 +125,7 @@ describe('electron:make command', function () {
     ).to.be.fulfilled;
     expect(api.make).to.be.calledOnce;
     expect(api.make.firstCall.args[0]).to.deep.equal({
-      dir: 'electron-app',
+      dir: path.resolve('electron-app'),
       outDir: path.resolve('some-dir'),
       platform: 'linux',
       arch: 'ia32',
@@ -137,7 +137,7 @@ describe('electron:make command', function () {
     await expect(command.validateAndRun(['--targets', 'zip'])).to.be.fulfilled;
     expect(api.make).to.be.calledOnce;
     expect(api.make.firstCall.args[0]).to.deep.equal({
-      dir: 'electron-app',
+      dir: path.resolve('electron-app'),
       outDir: path.join('electron-app', 'out'),
       skipPackage: false,
       overrideTargets: ['zip'],
@@ -149,7 +149,7 @@ describe('electron:make command', function () {
       .fulfilled;
     expect(api.make).to.be.calledOnce;
     expect(api.make.firstCall.args[0]).to.deep.equal({
-      dir: 'electron-app',
+      dir: path.resolve('electron-app'),
       outDir: path.join('electron-app', 'out'),
       skipPackage: false,
       overrideTargets: ['zip', 'dmg', 'deb'],
@@ -169,7 +169,9 @@ describe('electron:make command', function () {
     await expect(command.validateAndRun(['---publish'])).to.be.fulfilled;
 
     expect(api.publish).to.be.calledOnce;
-    expect(api.publish.firstCall.args[0].dir).to.equal('electron-app');
+    expect(api.publish.firstCall.args[0].dir).to.equal(
+      path.resolve('electron-app')
+    );
     expect(api.publish.firstCall.args[0].makeResults).to.equal(makeResults);
     expect(api.publish.firstCall.args[0].publishTargets).to.be.undefined;
   });

--- a/node-tests/integration/commands/package-test.js
+++ b/node-tests/integration/commands/package-test.js
@@ -44,7 +44,7 @@ describe('electron:package command', function () {
     );
     expect(api.package).to.be.calledOnce;
     expect(api.package.firstCall.args[0]).to.deep.equal({
-      dir: 'electron-app',
+      dir: path.resolve('electron-app'),
       outDir: path.join('electron-app', 'out'),
     });
     expect(api.package.firstCall).to.be.calledAfter(buildTaskStub.firstCall);
@@ -88,7 +88,7 @@ describe('electron:package command', function () {
     ).to.be.fulfilled;
     expect(api.package).to.be.calledOnce;
     expect(api.package.firstCall.args[0]).to.deep.equal({
-      dir: 'electron-app',
+      dir: path.resolve('electron-app'),
       outDir: path.resolve('some-dir'),
       platform: 'linux',
       arch: 'ia32',


### PR DESCRIPTION
making via the Webpack Plugin requires an absolute path.

This PR will resolve any **dir** option to the forge api...

https://github.com/adopted-ember-addons/ember-electron/issues/1501