### PR TITLE
Stop squashing module loading errors

### DIFF
--- a/vendor/wrap-require.js
+++ b/vendor/wrap-require.js
@@ -10,9 +10,9 @@
       } catch(error) {
         if (error.toString().includes('Error: Could not find module')) {
           return requireNode(...args);
+        } else {
+          throw error;
         }
-
-        console.error(error); // eslint-disable-line no-console
       }
     };
 


### PR DESCRIPTION
We've apparently been logging, rather than propagating, these errors for 8 years...and that seems very wrong. In particular, if there are test module load errors, they just get logged to the console, but cannot be detected by the test loader and turned into test failures. I think also this causes module load errors to be harder to detect/understand when running apps.

So, stop doing that, and propagate these errors!