### PR TITLE
Fix checking for packaged/dev modes

### DIFF
--- a/forge/files/src/index.js
+++ b/forge/files/src/index.js
@@ -31,7 +31,7 @@ app.on('window-all-closed', () => {
 });
 
 app.on('ready', async () => {
-  if (app.isPackaged) {
+  if (!app.isPackaged) {
     try {
       require('devtron').install();
     } catch (err) {


### PR DESCRIPTION
In the process of removing `electron-is-dev` (https://github.com/adopted-ember-addons/ember-electron/pull/1640) the way that we determine if we're in development environments changed, and as a result we need to invert the conditional.

Fixes: https://github.com/adopted-ember-addons/ember-electron/issues/1697