### PR TITLE
Switch to electron-extension-installer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,7 +93,7 @@ module.exports = {
             allowModules: [
               'devtron',
               'electron',
-              'electron-devtools-installer',
+              'electron-extension-installer',
               'ember-electron',
             ],
           },

--- a/forge/files/src/index.js
+++ b/forge/files/src/index.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 const {
-  default: installExtension,
+  installExtension,
   EMBER_INSPECTOR,
-} = require('electron-devtools-installer');
+} = require('electron-extension-installer');
 const { pathToFileURL } = require('url');
 const { app, BrowserWindow } = require('electron');
 const path = require('path');

--- a/forge/files/tests/index.js
+++ b/forge/files/tests/index.js
@@ -1,7 +1,7 @@
 const {
-  default: installExtension,
+  installExtension,
   EMBER_INSPECTOR,
-} = require('electron-devtools-installer');
+} = require('electron-extension-installer');
 const path = require('path');
 const { app } = require('electron');
 const handleFileUrls = require('../src/handle-file-urls');

--- a/forge/template.js
+++ b/forge/template.js
@@ -65,7 +65,7 @@ class EmberElectronTemplates extends BaseTemplate {
     return ['devtron'];
   }
   get dependencies() {
-    return ['electron-devtools-installer'];
+    return ['electron-extension-installer'];
   }
 
   async initializeTemplate(dir) {

--- a/node-tests/fixtures/ember-test/test-index-extra.js
+++ b/node-tests/fixtures/ember-test/test-index-extra.js
@@ -2,7 +2,7 @@
 // to make sure we don't have naming conflicts with already-declared variables
 function testIndexExtra() {
   // Make sure dependencies (node_modules) are loadable
-  require('electron-devtools-installer');
+  require('electron-extension-installer');
 
   // Make sure local libraries are loadable
   const helper = require('../src/helper');


### PR DESCRIPTION
electron-devtools-installer is old and unmaintained and uses a no-longer-supported API.

Fixes https://github.com/adopted-ember-addons/ember-electron/issues/1697